### PR TITLE
Updated $subdir variable to $f

### DIFF
--- a/includes/CCTM.php
+++ b/includes/CCTM.php
@@ -1318,7 +1318,7 @@ class CCTM {
 							if ( !preg_match('/^\./', $f2) && preg_match('/\.class\.php$/', $f2) ) {
 								$shortname = basename($f2);
 								$shortname = preg_replace('/\.class\.php$/', '', $shortname);
-								$files[$shortname] = $dir.'/'.$subdir.'/'.$f2;
+								$files[$shortname] = $dir.'/'.$f.'/'.$f2;
 							}
 						}
 					}


### PR DESCRIPTION
Code refactor in 0.9.6.1 changed the way helper classes are loaded and renamed the variable ($subdir) used for the subdirectory in the foreach loop to $f. $subdir remains on line 1304 although it isn't referenced anywhere else in this function.
